### PR TITLE
no need to install app twice

### DIFF
--- a/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
+++ b/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
@@ -2,6 +2,8 @@ package net.hpe;
 
 import static org.junit.Assert.*;
 
+import com.hp.lft.report.Reporter;
+import com.hp.lft.report.Status;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -101,6 +103,7 @@ public class LeanFtTest extends UnitTestClassBase {
                 System.out.println(grex.getMessage());
                 noProblem = false;
             }
+            Reporter.reportEvent("Error","Replay Exception", Status.Failed,grex);
         }
     }
 

--- a/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
+++ b/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
@@ -91,17 +91,19 @@ public class LeanFtTest extends UnitTestClassBase {
                 }
 
             } else {
-                System.out.println("======= Device couldn't be allocated, exiting script =======");
+                String msg = "======= Device couldn't be allocated, exiting script =======";
+                System.out.println(msg);
                 noProblem = false;
+                System.out.println("flynn");
+                Reporter.reportEvent("Error",msg, Status.Failed);
+                Assert.fail();
             }
         } catch (GeneralReplayException grex) {
             if (grex.getErrorCode() == 2036) {
                 System.out.println(grex.getMessage());
                 noProblem = false;
             }
-            System.out.println("flynn");
-            Reporter.reportEvent("Error","Replay Exception", Status.Failed,grex);
-            Assert.fail();
+
         }
     }
 

--- a/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
+++ b/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
@@ -4,11 +4,7 @@ import static org.junit.Assert.*;
 
 import com.hp.lft.report.Reporter;
 import com.hp.lft.report.Status;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import com.hp.lft.sdk.*;
 import com.hp.lft.verifications.*;
 
@@ -103,7 +99,9 @@ public class LeanFtTest extends UnitTestClassBase {
                 System.out.println(grex.getMessage());
                 noProblem = false;
             }
+            System.out.println("flynn");
             Reporter.reportEvent("Error","Replay Exception", Status.Failed,grex);
+            Assert.fail();
         }
     }
 

--- a/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
+++ b/pwc-moved-obj/src/main/java/net/hpe/LeanFtTest.java
@@ -86,7 +86,8 @@ public class LeanFtTest extends UnitTestClassBase {
                 if (INSTALL_APP) {
                     System.out.println("Installing app: " + app.getIdentifier());
                     System.out.println("Version: " + APP_VERSION);
-                    app.install();
+                    //app.install();
+                    app.launch();
                 } else {
                     app.restart();
                 }


### PR DESCRIPTION
 MobileLab.lockDevice on line 152 is installing the app based on the appDescription so this can be removed to save time and confusion.  Instead, I just launch the app.